### PR TITLE
Add ability to contribute custom BreakIterator via OSGi service #289

### DIFF
--- a/org.eclipse.draw2d.tests/.project
+++ b/org.eclipse.draw2d.tests/.project
@@ -20,6 +20,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>

--- a/org.eclipse.draw2d.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d.tests
-Bundle-Version: 3.12.200.qualifier
+Bundle-Version: 3.12.300.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
@@ -12,4 +12,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jface;bundle-version="[3.2.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.draw2d.tests
+Service-Component: OSGI-INF/org.eclipse.draw2d.test.TextFlowWrapTest$BreakIteratorFactoryMock.xml
+Bundle-ActivationPolicy: lazy
 

--- a/org.eclipse.draw2d.tests/OSGI-INF/org.eclipse.draw2d.test.TextFlowWrapTest$BreakIteratorFactoryMock.xml
+++ b/org.eclipse.draw2d.tests/OSGI-INF/org.eclipse.draw2d.test.TextFlowWrapTest$BreakIteratorFactoryMock.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.draw2d.test.TextFlowWrapTest$BreakIteratorFactoryMock">
+   <service>
+      <provide interface="org.eclipse.draw2d.text.BreakIteratorFactory"/>
+   </service>
+   <implementation class="org.eclipse.draw2d.test.TextFlowWrapTest$BreakIteratorFactoryMock"/>
+</scr:component>

--- a/org.eclipse.draw2d.tests/build.properties
+++ b/org.eclipse.draw2d.tests/build.properties
@@ -12,7 +12,8 @@
 ###############################################################################
 bin.includes = plugin.properties,\
                .,\
-               META-INF/
+               META-INF/,\
+               OSGI-INF/org.eclipse.draw2d.test.TextFlowWrapTest$BreakIteratorFactoryMock.xml
 jars.compile.order = .
 source.. = src/
 output.. = bin/

--- a/org.eclipse.draw2d.tests/pom.xml
+++ b/org.eclipse.draw2d.tests/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.draw2d.plugins</groupId>
 	<artifactId>org.eclipse.draw2d.tests</artifactId>
-	<version>3.12.200-SNAPSHOT</version>
+	<version>3.12.300-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<profiles>
 		<profile>

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/BaseTestCase.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/BaseTestCase.java
@@ -32,6 +32,7 @@ import org.junit.Assert;
 public abstract class BaseTestCase extends Assert {
 
 	protected static final Font TAHOMA = new Font(null, "Tahoma", 8, 0);//$NON-NLS-1$
+	protected static final Font SERIF = new Font(null, "Serif", 8, 0);//$NON-NLS-1$
 
 	public static void assertEquals(Image expected, Image actual) {
 		assertTrue("The given images did not match", //$NON-NLS-1$

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ColorConstantTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ColorConstantTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2010 IBM Corporation and others.
+ * Copyright (c) 2006, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,14 +15,13 @@ package org.eclipse.draw2d.test;
 import org.eclipse.swt.widgets.Display;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore
 public class ColorConstantTest extends Assert {
 
 	@Test
-	public static void testColorConstantInit() {
+	@SuppressWarnings("static-method")
+	public void testColorConstantInit() {
 		final Boolean[] result = new Boolean[2];
 		result[0] = Boolean.FALSE;
 		result[1] = Boolean.FALSE;

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TextFlowWrapTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TextFlowWrapTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,21 +12,21 @@
  *******************************************************************************/
 package org.eclipse.draw2d.test;
 
+import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.Iterator;
 
 import org.eclipse.draw2d.FigureUtilities;
+import org.eclipse.draw2d.text.BreakIteratorFactory;
 import org.eclipse.draw2d.text.FlowPage;
 import org.eclipse.draw2d.text.InlineFlow;
 import org.eclipse.draw2d.text.ParagraphTextLayout;
 import org.eclipse.draw2d.text.TextFlow;
 import org.eclipse.draw2d.text.TextFragmentBox;
 
-import org.junit.Ignore;
 import org.junit.Test;
+import org.osgi.service.component.annotations.Component;
 
-// FIXME The text flow wrap test are currently unstable and therefore deactivated
-@Ignore
 public class TextFlowWrapTest extends BaseTestCase {
 
 	// @TODO:Pratik create similar test cases for bidi...where the fragments are
@@ -57,7 +57,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 	protected void doTest2(String string1, String string2, String widthString, String[] answers) {
 		int width = -1;
 		if (widthString != null) {
-			width = FigureUtilities.getStringExtents(widthString, TAHOMA).width;
+			width = FigureUtilities.getStringExtents(widthString, SERIF).width;
 		}
 		figure.setSize(width, 1000);
 		textFlow.setText(string1);
@@ -269,11 +269,11 @@ public class TextFlowWrapTest extends BaseTestCase {
 		figure = new FlowPage();
 		textFlow = new TextFlow();
 		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_HARD));
-		textFlow.setFont(TAHOMA);
+		textFlow.setFont(SERIF);
 		figure.add(textFlow);
 		textFlow2 = new TextFlow();
 		textFlow2.setLayoutManager(new ParagraphTextLayout(textFlow2, ParagraphTextLayout.WORD_WRAP_HARD));
-		textFlow2.setFont(TAHOMA);
+		textFlow2.setFont(SERIF);
 		figure.add(textFlow2);
 
 		runGenericTests();
@@ -285,11 +285,11 @@ public class TextFlowWrapTest extends BaseTestCase {
 		figure = new FlowPage();
 		textFlow = new TextFlow();
 		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_SOFT));
-		textFlow.setFont(TAHOMA);
+		textFlow.setFont(SERIF);
 		figure.add(textFlow);
 		textFlow2 = new TextFlow();
 		textFlow2.setLayoutManager(new ParagraphTextLayout(textFlow2, ParagraphTextLayout.WORD_WRAP_SOFT));
-		textFlow2.setFont(TAHOMA);
+		textFlow2.setFont(SERIF);
 		figure.add(textFlow2);
 
 		runGenericTests();
@@ -301,11 +301,11 @@ public class TextFlowWrapTest extends BaseTestCase {
 		figure = new FlowPage();
 		textFlow = new TextFlow();
 		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_TRUNCATE));
-		textFlow.setFont(TAHOMA);
+		textFlow.setFont(SERIF);
 		figure.add(textFlow);
 		textFlow2 = new TextFlow();
 		textFlow2.setLayoutManager(new ParagraphTextLayout(textFlow2, ParagraphTextLayout.WORD_WRAP_TRUNCATE));
-		textFlow2.setFont(TAHOMA);
+		textFlow2.setFont(SERIF);
 		figure.add(textFlow2);
 
 		runGenericTests();
@@ -318,12 +318,12 @@ public class TextFlowWrapTest extends BaseTestCase {
 		InlineFlow inline = new InlineFlow();
 		textFlow = new TextFlow();
 		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_SOFT));
-		textFlow.setFont(TAHOMA);
+		textFlow.setFont(SERIF);
 		inline.add(textFlow);
 		figure.add(inline);
 		textFlow2 = new TextFlow();
 		textFlow2.setLayoutManager(new ParagraphTextLayout(textFlow2, ParagraphTextLayout.WORD_WRAP_SOFT));
-		textFlow2.setFont(TAHOMA);
+		textFlow2.setFont(SERIF);
 		figure.add(textFlow2);
 		runGenericTests();
 		runSoftWrappingTests();
@@ -332,12 +332,12 @@ public class TextFlowWrapTest extends BaseTestCase {
 		inline = new InlineFlow();
 		textFlow = new TextFlow();
 		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_HARD));
-		textFlow.setFont(TAHOMA);
+		textFlow.setFont(SERIF);
 		inline.add(textFlow);
 		figure.add(inline);
 		textFlow2 = new TextFlow();
 		textFlow2.setLayoutManager(new ParagraphTextLayout(textFlow2, ParagraphTextLayout.WORD_WRAP_HARD));
-		textFlow2.setFont(TAHOMA);
+		textFlow2.setFont(SERIF);
 		figure.add(textFlow2);
 		runGenericTests();
 		runHardWrappingTests();
@@ -349,7 +349,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 		figure = new FlowPage();
 		textFlow = new TextFlow();
 		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_SOFT));
-		textFlow.setFont(TAHOMA);
+		textFlow.setFont(SERIF);
 		figure.add(textFlow);
 		InlineFlow inline = new InlineFlow();
 		figure.add(inline);
@@ -357,7 +357,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 		inline.add(inline2);
 		textFlow2 = new TextFlow();
 		textFlow2.setLayoutManager(new ParagraphTextLayout(textFlow2, ParagraphTextLayout.WORD_WRAP_SOFT));
-		textFlow2.setFont(TAHOMA);
+		textFlow2.setFont(SERIF);
 		inline2.add(textFlow2);
 		runGenericTests();
 		runSoftWrappingTests();
@@ -365,7 +365,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 		figure = new FlowPage();
 		textFlow = new TextFlow();
 		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_HARD));
-		textFlow.setFont(TAHOMA);
+		textFlow.setFont(SERIF);
 		figure.add(textFlow);
 		inline = new InlineFlow();
 		figure.add(inline);
@@ -373,11 +373,18 @@ public class TextFlowWrapTest extends BaseTestCase {
 		inline.add(inline2);
 		textFlow2 = new TextFlow();
 		textFlow2.setLayoutManager(new ParagraphTextLayout(textFlow2, ParagraphTextLayout.WORD_WRAP_HARD));
-		textFlow2.setFont(TAHOMA);
+		textFlow2.setFont(SERIF);
 		inline2.add(textFlow2);
 		runGenericTests();
 		runHardWrappingTests();
 		doTest2("def", "def", "defde", new String[] { "def", SAMELINE, "def", TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 	}
 
+	@Component
+	public static class BreakIteratorFactoryMock implements BreakIteratorFactory {
+		@Override
+		public BreakIterator newInstance() {
+			return BreakIterator.getLineInstance();
+		}
+	}
 }

--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Export-Package: org.eclipse.draw2d,
  org.eclipse.draw2d.text,
  org.eclipse.draw2d.widgets,
  org.eclipse.draw2d.zoom
-Import-Package: com.ibm.icu.text
+Import-Package: com.ibm.icu.text,
+ org.osgi.framework;version="[1.0.0,2.0.0)"
 Require-Bundle: org.eclipse.swt;bundle-version="[3.4.0,4.0.0)";visibility:=reexport
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BreakIteratorFactory.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BreakIteratorFactory.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.text;
+
+import java.text.BreakIterator;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+
+/**
+ *
+ * @since 3.15
+ */
+public interface BreakIteratorFactory {
+	BreakIterator newInstance();
+
+	static BreakIterator getInstance() {
+		Bundle bundle = FrameworkUtil.getBundle(BreakIteratorFactory.class);
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		ServiceReference<BreakIteratorFactory> serviceReference = bundleContext
+				.getServiceReference(BreakIteratorFactory.class);
+
+		if (serviceReference == null) {
+			return BreakIterator.getLineInstance();
+		}
+
+		try {
+			BreakIteratorFactory factory = bundleContext.getService(serviceReference);
+			return factory.newInstance();
+		} finally {
+			bundleContext.ungetService(serviceReference);
+		}
+	}
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d.text;
 
+import java.text.BreakIterator;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Rectangle;
@@ -20,8 +22,6 @@ import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.TextUtilities;
-
-import com.ibm.icu.text.BreakIterator;
 
 /**
  * Utility class for FlowFigures.
@@ -40,10 +40,10 @@ public class FlowUtilities {
 	 */
 	public static FlowUtilities INSTANCE = new FlowUtilities();
 
-	private static final BreakIterator INTERNAL_LINE_BREAK = BreakIterator.getLineInstance();
+	private static final BreakIterator INTERNAL_LINE_BREAK = BreakIteratorFactory.getInstance();
 	private static TextLayout layout;
 
-	static final BreakIterator LINE_BREAK = BreakIterator.getLineInstance();
+	static final BreakIterator LINE_BREAK = BreakIteratorFactory.getInstance();
 
 	static boolean canBreakAfter(char c) {
 		boolean result = Character.isWhitespace(c) || c == '-';


### PR DESCRIPTION
With this change, GEF uses the native Java BreakIterator by default. If downstream project require a different implementation (e.g. the ICU one), they can do so via the newly introduced BreakIteratorFactory.